### PR TITLE
doc: fix link to Code of Conduct for contributing

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/jamesmacwilliam/percona_ar. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](contributor-covenant.org) code of conduct.
+Bug reports and pull requests are welcome on GitHub at https://github.com/jamesmacwilliam/percona_ar. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](CODE_OF_CONDUCT.md) code of conduct.
 
 
 ## License


### PR DESCRIPTION
The previous link:

https://github.com/jamesmacwilliam/percona_ar/blob/master/contributor-covenant.org

This link resulted in a 404 not found error.  The new link:

https://github.com/jamesmacwilliam/percona_ar/blob/master/CODE_OF_CONDUCT.md
