### PR TITLE
Handle multiple updates to same table in one percona call

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 require "bundler/setup"
-require "percona_ar_migration"
+require "percona_ar"
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.

--- a/lib/percona_ar.rb
+++ b/lib/percona_ar.rb
@@ -3,6 +3,7 @@ require "active_record"
 require "active_record/connection_adapters/mysql2_adapter"
 require "percona_ar/version"
 require "percona_ar/pt_online_schema_change_executor"
+require "percona_ar/query_builder"
 require "percona_ar/connection"
 require "percona_ar/migration"
 

--- a/lib/percona_ar/connection.rb
+++ b/lib/percona_ar/connection.rb
@@ -10,7 +10,7 @@ class PerconaAr::Connection < ActiveRecord::ConnectionAdapters::Mysql2Adapter
 
   def execute(sql, name = nil)
     return super unless sql =~ /^ALTER TABLE.*/
-    PerconaAr::PtOnlineSchemaChangeExecutor.new(sql).call
+    $query_builder.add sql
   end
 
   def not_implemented(*)

--- a/lib/percona_ar/migration.rb
+++ b/lib/percona_ar/migration.rb
@@ -3,4 +3,10 @@ class PerconaAr::Migration < ActiveRecord::Migration
     @percona_connection ||=
       PerconaAr::Connection.new(ActiveRecord::Base.connection)
   end
+
+  def migrate(*args)
+    $query_builder = PerconaAr::QueryBuilder.new
+    super
+    $query_builder.execute
+  end
 end

--- a/lib/percona_ar/pt_online_schema_change_executor.rb
+++ b/lib/percona_ar/pt_online_schema_change_executor.rb
@@ -4,27 +4,21 @@ require 'rake/file_utils'
 class PerconaAr::PtOnlineSchemaChangeExecutor
   include FileUtils
 
-  attr_accessor :sql
+  attr_accessor :sql, :table
 
-  def initialize(sql)
+  def initialize(table, sql)
+    @table = table
     @sql = sql
   end
 
   def call
-    if sql =~ /^ALTER TABLE `([^`]*)` (.*)/i
-      sh "#{boilerplate}#{suffix($1, $2)}"
-    end
+    sh "#{boilerplate}#{suffix(table, sql)}"
   end
 
   private
 
   def suffix(table, cmd)
-    "'#{get_sql_for(cmd)}' --recursion-method none --no-check-alter --execute D=#{config[:database]},t=#{table}"
-  end
-
-  def get_sql_for(cmd)
-    return cmd unless cmd =~ /DROP/i && !(cmd =~ /COLUMN/i)
-    cmd.gsub(/DROP/i, "DROP COLUMN")
+    "'#{cmd}' --recursion-method none --no-check-alter --execute D=#{config[:database]},t=#{table}"
   end
 
   def boilerplate

--- a/lib/percona_ar/query_builder.rb
+++ b/lib/percona_ar/query_builder.rb
@@ -1,0 +1,26 @@
+class PerconaAr::QueryBuilder
+  def initialize
+    @tables = Hash.new {|h, k| h[k] = [] }
+  end
+
+  def execute
+    @tables.each do |table, snippets|
+      PerconaAr::PtOnlineSchemaChangeExecutor.new(table, snippets.join(", ")).call
+    end
+  end
+
+  def add(sql)
+    if sql =~ /^ALTER TABLE `([^`]*)` (.*)/i
+      @tables[$1.to_s] << get_sql_for($2)
+    end
+    self
+  end
+
+  private
+
+  def get_sql_for(cmd)
+    return cmd unless cmd =~ /DROP/i && !(cmd =~ /COLUMN/i)
+    cmd.gsub(/DROP/i, "DROP COLUMN")
+  end
+
+end

--- a/spec/integration/percona_ar_e2e_spec.rb
+++ b/spec/integration/percona_ar_e2e_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+RSpec.describe "End to End" do
+  let!(:executor) { PerconaAr::PtOnlineSchemaChangeExecutor.new("", "") }
+
+  before do
+    ActiveRecord::Migration.create_table :foos
+    ActiveRecord::Migration.create_table :foos2
+    allow(PerconaAr::PtOnlineSchemaChangeExecutor).
+      to receive(:new) { executor }
+  end
+
+  after  do
+    ActiveRecord::Migration.drop_table :foos
+    ActiveRecord::Migration.drop_table :foos2
+  end
+
+  describe "when adding several columns from one table" do
+    class ManyCols < PerconaAr::Migration
+      def change
+        add_column :foos, :bar, :text
+        add_column :foos, :bat, :text
+      end
+    end
+
+    it "only uses the pt-osc tool once for both columns" do
+      expect(executor).to receive(:sh).once
+      ManyCols.migrate :up
+    end
+
+  end
+
+  describe "when adding columns from several tables" do
+    class ManyTables < PerconaAr::Migration
+      def change
+        add_column :foos,  :bar, :text
+        add_column :foos2, :bar , :text
+      end
+    end
+
+    it "uses pt-osc tool once per table" do
+      expect(executor).to receive(:sh).twice
+      ManyTables.migrate :up
+    end
+  end
+end

--- a/spec/lib/percona_ar/connection_spec.rb
+++ b/spec/lib/percona_ar/connection_spec.rb
@@ -2,10 +2,10 @@ require 'spec_helper'
 
 RSpec.describe PerconaAr::Connection do
   let!(:lib) { described_class.new(ActiveRecord::Base.connection) }
-  let(:executor) { PerconaAr::PtOnlineSchemaChangeExecutor }
+  let(:builder) { $query_builder }
 
   before do
-    allow(executor).to receive(:new) { double(:call => "") }
+    allow(builder).to receive(:add)
     allow_any_instance_of(ActiveRecord::ConnectionAdapters::Mysql2Adapter).
       to receive(:execute)
   end
@@ -19,13 +19,13 @@ RSpec.describe PerconaAr::Connection do
   describe "#execute" do
     it "uses percona tool when sql is an alter statement" do
       sql = "ALTER TABLE `users` drop column `foo`"
-      expect(executor).to receive(:new).with(sql)
+      expect(builder).to receive(:add).with(sql)
       lib.execute(sql)
     end
 
     it "uses ActiveRecord when sql is not an alter statement" do
       sql = "SHOW FIELDS FOR users"
-      expect(executor).not_to receive(:new)
+      expect(builder).not_to receive(:add)
       lib.execute(sql)
     end
   end

--- a/spec/lib/percona_ar/pt_online_schema_change_executor_spec.rb
+++ b/spec/lib/percona_ar/pt_online_schema_change_executor_spec.rb
@@ -3,36 +3,17 @@ require 'spec_helper'
 RSpec.describe PerconaAr::PtOnlineSchemaChangeExecutor do
   describe "#call" do
 
-    let(:lib) { described_class.new(sql) }
+    let(:lib) { described_class.new("users", sql) }
+    let(:sql) { "`foo` `bar` varchar(36)" }
 
     after { lib.call }
     subject { lib }
 
-    context "when sql does not have alter statement" do
-      let(:sql) { "SELECT * FROM `USERS`" }
-
-      it { is_expected.not_to receive(:sh) }
-    end
-
-    context "when sql has alter statement" do
-      let(:sql) { "alter table `users` `foo` `bar` varchar(36)" }
-      it { is_expected.to receive(:sh).with(/pt.online.schema.change.*[-]u.*[-]h.*[-]p.*alter.*foo.*execute.D.#{$db_name.gsub("_", ".")}.t.users/) }
-
-    end
-    context "when sql has alter statement with DROP but no column" do
-      let(:sql) { "alter table `users` drop `foo`" }
-
-      it "adds 'COLUMN' to drop statement in order to be valid for percona" do
-        is_expected.to receive(:sh).with(/alter.*DROP COLUMN..foo/)
-      end
-    end
-
-    context"when sql has alter statement with DROP and column specification" do
-      let(:sql) { "alter table `users` drop column `foo`" }
-
-      it "leaves sql unchanged" do
-        is_expected.to receive(:sh).with(/alter.*drop column..foo/)
-      end
+    it "build correct command" do
+      is_expected.to receive(:sh).
+        with(
+          /pt.online.schema.change.*[-]u.*[-]h.*[-]p.*alter.*foo.*execute.D.#{$db_name.gsub("_", ".")}.t.users/
+        )
     end
   end
 end

--- a/spec/lib/percona_ar/query_builder_spec.rb
+++ b/spec/lib/percona_ar/query_builder_spec.rb
@@ -1,0 +1,66 @@
+require 'spec_helper'
+
+RSpec.describe PerconaAr::QueryBuilder do
+  let(:builder) { described_class.new }
+  subject(:executor) { PerconaAr::PtOnlineSchemaChangeExecutor }
+  before { allow_any_instance_of(executor).to receive(:sh) }
+
+  describe "#execute" do
+    after { builder.execute }
+
+    context "many tables" do
+      before do
+        builder.add "alter table `users` `foo` `bar` varchar(36)"
+        builder.add "alter table `users2` `foo` `bar` varchar(36)"
+      end
+
+      it { is_expected.not_to receive(:new).
+           and_call_original.twice }
+    end
+
+    context "many updates to the same table" do
+      before do
+        builder.add "alter table `users` `foo` `bar` varchar(36)"
+        builder.add "alter table `users` `foos` `bar` varchar(36)"
+      end
+
+      it { is_expected.not_to receive(:new).
+           and_call_original.once }
+    end
+  end
+
+  describe "#add" do
+    after { builder.add(sql).execute }
+    before { allow_any_instance_of(executor).to receive(:sh) }
+
+    context "when sql does not have alter statement" do
+      let(:sql) { "SELECT * FROM `USERS`" }
+
+      it { is_expected.not_to receive(:new) }
+    end
+
+    context "when sql has alter statement" do
+      let(:sql) { "alter table `users` `foo` `bar` varchar(36)" }
+      it { is_expected.to receive(:new).with("users", /foo.*bar/).
+           and_call_original }
+
+    end
+    context "when sql has alter statement with DROP but no column" do
+      let(:sql) { "alter table `users` drop `foo`" }
+
+      it "adds 'COLUMN' to drop statement in order to be valid for percona" do
+        is_expected.to receive(:new).with("users", /DROP COLUMN..foo/).
+          and_call_original
+      end
+    end
+
+    context"when sql has alter statement with DROP and column specification" do
+      let(:sql) { "alter table `users` drop column `foo`" }
+
+      it "leaves sql unchanged" do
+        is_expected.to receive(:new).with("users", /drop column..foo/).
+          and_call_original
+      end
+    end
+  end
+end


### PR DESCRIPTION
- percona calls are expensive, especially on large tables so we want to
  minimize them if possible
- this groups update statements within a migration class that are done
  on a particular table into one percona call
- multiple tables within the same migration will still be multiple
  percona calls
- this is achieved my wrapping Migration#migrate with a builder that is
  added to on connection#execute and then executes all the built up sql
  by table at the end of the #migrate call
