### PR TITLE
Fix invalid MySQL syntax for string default values

### DIFF
--- a/lib/percona_ar/pt_online_schema_change_executor.rb
+++ b/lib/percona_ar/pt_online_schema_change_executor.rb
@@ -12,13 +12,13 @@ class PerconaAr::PtOnlineSchemaChangeExecutor
   end
 
   def call
-    sh "#{boilerplate}#{suffix(table, sql)}"
+    sh %Q(#{boilerplate}#{suffix(table, sql)})
   end
 
   private
 
   def suffix(table, cmd)
-    "'#{cmd}' --recursion-method none --no-check-alter --execute D=#{config[:database]},t=#{table}"
+    %Q('#{cmd.gsub("'","\"")}' --recursion-method none --no-check-alter --execute D=#{config[:database]},t=#{table})
   end
 
   def boilerplate

--- a/lib/percona_ar/version.rb
+++ b/lib/percona_ar/version.rb
@@ -1,3 +1,3 @@
 module PerconaAr
-  VERSION = "0.1.3"
+  VERSION = "0.1.4"
 end


### PR DESCRIPTION
Generate valid MySQL syntax when executing ALTER statements for NOT NULL columns that have string default values