### PR TITLE
Add feature to override connection

### DIFF
--- a/lib/percona_ar/migration.rb
+++ b/lib/percona_ar/migration.rb
@@ -5,7 +5,7 @@ class PerconaAr::Migration < ActiveRecord::Migration
   end
 
   def migrate(*args)
-    $query_builder = PerconaAr::QueryBuilder.new
+    $query_builder = PerconaAr::QueryBuilder.new connection
     super
     $query_builder.execute
   end

--- a/lib/percona_ar/pt_online_schema_change_executor.rb
+++ b/lib/percona_ar/pt_online_schema_change_executor.rb
@@ -6,7 +6,7 @@ class PerconaAr::PtOnlineSchemaChangeExecutor
 
   attr_accessor :sql, :table, :conn
 
-  def initialize(table, sql, conn)
+  def initialize(table, sql, conn = ActiveRecord::Base.connection)
     @table = table
     @sql = sql
     @conn = conn

--- a/lib/percona_ar/pt_online_schema_change_executor.rb
+++ b/lib/percona_ar/pt_online_schema_change_executor.rb
@@ -4,11 +4,12 @@ require 'rake/file_utils'
 class PerconaAr::PtOnlineSchemaChangeExecutor
   include FileUtils
 
-  attr_accessor :sql, :table
+  attr_accessor :sql, :table, :conn
 
-  def initialize(table, sql)
+  def initialize(table, sql, conn)
     @table = table
     @sql = sql
+    @conn = conn
   end
 
   def call
@@ -26,6 +27,6 @@ class PerconaAr::PtOnlineSchemaChangeExecutor
   end
 
   def config
-    ActiveRecord::Base.connection_config
+    conn.instance_variable_get(:@config)
   end
 end

--- a/lib/percona_ar/query_builder.rb
+++ b/lib/percona_ar/query_builder.rb
@@ -1,5 +1,5 @@
 class PerconaAr::QueryBuilder
-  def initialize(conn)
+  def initialize(conn = ActiveRecord::Base.connection)
     @tables = Hash.new {|h, k| h[k] = [] }
     @conn = conn
   end

--- a/lib/percona_ar/query_builder.rb
+++ b/lib/percona_ar/query_builder.rb
@@ -1,11 +1,12 @@
 class PerconaAr::QueryBuilder
-  def initialize
+  def initialize(conn)
     @tables = Hash.new {|h, k| h[k] = [] }
+    @conn = conn
   end
 
   def execute
     @tables.each do |table, snippets|
-      PerconaAr::PtOnlineSchemaChangeExecutor.new(table, snippets.join(", ")).call
+      PerconaAr::PtOnlineSchemaChangeExecutor.new(table, snippets.join(", "), @conn).call
     end
   end
 

--- a/spec/lib/percona_ar/query_builder_spec.rb
+++ b/spec/lib/percona_ar/query_builder_spec.rb
@@ -41,7 +41,8 @@ RSpec.describe PerconaAr::QueryBuilder do
 
     context "when sql has alter statement" do
       let(:sql) { "alter table `users` `foo` `bar` varchar(36)" }
-      it { is_expected.to receive(:new).with("users", /foo.*bar/).
+      it { is_expected.to receive(:new).
+           with("users", /foo.*bar/, ActiveRecord::Base.connection).
            and_call_original }
 
     end
@@ -49,7 +50,8 @@ RSpec.describe PerconaAr::QueryBuilder do
       let(:sql) { "alter table `users` drop `foo`" }
 
       it "adds 'COLUMN' to drop statement in order to be valid for percona" do
-        is_expected.to receive(:new).with("users", /DROP COLUMN..foo/).
+        is_expected.to receive(:new).
+          with("users", /DROP COLUMN..foo/, ActiveRecord::Base.connection).
           and_call_original
       end
     end
@@ -58,7 +60,8 @@ RSpec.describe PerconaAr::QueryBuilder do
       let(:sql) { "alter table `users` drop column `foo`" }
 
       it "leaves sql unchanged" do
-        is_expected.to receive(:new).with("users", /drop column..foo/).
+        is_expected.to receive(:new).
+          with("users", /drop column..foo/, ActiveRecord::Base.connection).
           and_call_original
       end
     end


### PR DESCRIPTION
Hello

I use this gem in my project and this gem is really great! Thank you for your development. 
I use it with gems like [switch_point](https://github.com/eagletmt/switch_point). They add features to connect multiple databases(Vertical partitioning by tables). Therefore I need to switch connection when database migration, so I added its feature.

This is example of usage.

```ruby
class SomeAwesomeMigration < PerconaAr::Migration
  def connection
    @percona_connection ||= PerconaAr::Connection.new(SomeModel.connection)
  end

  def change
    # ALTER commands will get run by the Percona tool,
    # all other commands will get run by ActiveRecord
    ...
  end
end
```

Thank you.