### PR TITLE
Add alter-foreign-keys-method

### DIFF
--- a/lib/percona_ar/pt_online_schema_change_executor.rb
+++ b/lib/percona_ar/pt_online_schema_change_executor.rb
@@ -19,7 +19,7 @@ class PerconaAr::PtOnlineSchemaChangeExecutor
   private
 
   def suffix(table, cmd)
-    %Q('#{cmd.gsub("'","\"")}' --recursion-method none --no-check-alter --execute D=#{config[:database]},t=#{table})
+    %Q('#{cmd.gsub("'","\"")}' --recursion-method none --no-check-alter --alter-foreign-keys-method 'auto' --execute D=#{config[:database]},t=#{table})
   end
 
   def boilerplate

--- a/spec/lib/percona_ar/pt_online_schema_change_executor_spec.rb
+++ b/spec/lib/percona_ar/pt_online_schema_change_executor_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe PerconaAr::PtOnlineSchemaChangeExecutor do
     it "build correct command" do
       is_expected.to receive(:sh).
         with(
-          /pt.online.schema.change.*[-]u.*[-]h.*[-]p.*alter.*foo.*execute.D.#{$db_name.gsub("_", ".")}.t.users/
+          /pt.online.schema.change.*[-]u.*[-]h.*[-]p.*alter.*foo.*alter-foreign-keys-method.*auto.*execute.D.#{$db_name.gsub("_", ".")}.t.users/
         )
     end
   end


### PR DESCRIPTION
- pt-online-schema-change requires this option to be set explicitly when
dealing with any index manipulation