### PR TITLE
Ensure that we only substitute for DROP if it is the keyword

### DIFF
--- a/lib/percona_ar/query_builder.rb
+++ b/lib/percona_ar/query_builder.rb
@@ -27,7 +27,7 @@ class PerconaAr::QueryBuilder
   def get_sql_for(cmd)
     return cmd unless cmd =~ /DROP/i && !(cmd =~ /COLUMN/i)
     return cmd if cmd =~ /DROP INDEX/i
-    cmd.gsub(/DROP/i, "DROP COLUMN")
+    cmd.gsub(/(^| )DROP /i, " DROP COLUMN ")
   end
 
 end

--- a/spec/lib/percona_ar/query_builder_spec.rb
+++ b/spec/lib/percona_ar/query_builder_spec.rb
@@ -54,6 +54,14 @@ RSpec.describe PerconaAr::QueryBuilder do
            and_call_original }
     end
 
+    context "when sql has alter statement with DROP as part of a column name" do
+      let(:sql) { "alter table `users` `drop_count` varchar(36)" }
+
+      it { is_expected.to receive(:new).
+           with("users", /drop_count.*varchar/, ActiveRecord::Base.connection).
+           and_call_original }
+    end
+
     context "when sql has alter statement with DROP but no column" do
       let(:sql) { "alter table `users` drop `foo`" }
 


### PR DESCRIPTION
- we don't want to substitute for drop if it is part of a column name

closes #5 